### PR TITLE
Fix race in 'executeOperation(props:operation)'

### DIFF
--- a/Sources/Queue/AsyncQueue.swift
+++ b/Sources/Queue/AsyncQueue.swift
@@ -118,12 +118,12 @@ public final class AsyncQueue: @unchecked Sendable {
 		props: ExecutionProperties,
 		@_inheritActorContext operation: @escaping ThrowingOperation<Success>
 	) async rethrows -> Success {
-		for awaitable in props.dependencies {
-			await awaitable.waitForCompletion()
-		}
-
 		defer {
 			completePendingTask(with: props)
+		}
+
+		for awaitable in props.dependencies {
+			await awaitable.waitForCompletion()
 		}
 
 		do {


### PR DESCRIPTION
If the task got cancelled while still waiting for dependencies, 'completePendingTask(with:)' was not executed, leaving a zombie in the queue.

The fix is to move the defer clause to the very beginning of the function.